### PR TITLE
Feature: Multi-Head Attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add `benchmarks` infrastructure.
 - An `Operator` now takes a `device` argument.
 - Add `QuantileScaler` class.
+- Add `Attention` base class, `MultiHeadAttention`, and `ScaledDotProductAttention` classes.
 
 ## 0.0.0 (2024-02-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## 0.1
+## 0.2.0
+
+- Add `Attention` base class, `MultiHeadAttention`, and `ScaledDotProductAttention` classes.
+
+## 0.1.0
 
 - Move all content of `__init__.py` files to sub-modules.
 - Add `Trainer` class to replace `operator.fit` method.
@@ -24,7 +28,6 @@
 - Add `benchmarks` infrastructure.
 - An `Operator` now takes a `device` argument.
 - Add `QuantileScaler` class.
-- Add `Attention` base class, `MultiHeadAttention`, and `ScaledDotProductAttention` classes.
 
 ## 0.0.0 (2024-02-22)
 

--- a/src/continuiti/networks/__init__.py
+++ b/src/continuiti/networks/__init__.py
@@ -6,5 +6,12 @@ Networks in continuiti.
 
 from .fully_connected import FullyConnected
 from .deep_residual_network import DeepResidualNetwork
+from .multi_head_attention import MultiHeadAttention
+from .scaled_dot_product_attention import ScaledDotProductAttention
 
-__all__ = ["FullyConnected", "DeepResidualNetwork"]
+__all__ = [
+    "FullyConnected",
+    "DeepResidualNetwork",
+    "MultiHeadAttention",
+    "ScaledDotProductAttention",
+]

--- a/src/continuiti/networks/attention.py
+++ b/src/continuiti/networks/attention.py
@@ -12,10 +12,10 @@ import torch
 class Attention(nn.Module):
     """Base class for various attention implementations.
 
-    Attention assigns different parts of an input varying importance without set kernels. The importance of different
-    components is designated using "soft" weights. These weights are assigned according to specific algorithms (e.g.
+    Attention assigns different parts of an input varying importance without set
+    kernels. The importance of different components is designated using "soft"
+    weights. These weights are assigned according to specific algorithms (e.g.
     scaled-dot-product attention).
-
     """
 
     def __init__(self):
@@ -26,7 +26,7 @@ class Attention(nn.Module):
         self,
         query: torch.Tensor,
         key: torch.Tensor,
-        value: torch,
+        value: torch.Tensor,
         attn_mask: torch.Tensor = None,
     ) -> torch.Tensor:
         """Calculates the attention scores.

--- a/src/continuiti/networks/attention.py
+++ b/src/continuiti/networks/attention.py
@@ -1,0 +1,44 @@
+"""
+`continuiti.networks.attention`
+
+Attention base class in continuiti.
+"""
+
+from abc import abstractmethod
+import torch.nn as nn
+import torch
+
+
+class Attention(nn.Module):
+    """Base class for various attention implementations.
+
+    Attention assigns different parts of an input varying importance without set kernels. The importance of different
+    components is designated using "soft" weights. These weights are assigned according to specific algorithms (e.g.
+    scaled-dot-product attention).
+
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    @abstractmethod
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch,
+        attn_mask: torch.Tensor = None,
+    ) -> torch.Tensor:
+        """Calculates the attention scores.
+
+        Args:
+            query: query tensor; shape (batch_size, target_seq_length, hidden_dim)
+            key: key tensor; shape (batch_size, source_seq_length, hidden_dim)
+            value: value tensor; shape (batch_size, source_seq_length, hidden_dim)
+            attn_mask: tensor indicating which values are used to calculate the output;
+                shape (batch_size, target_seq_length, source_seq_length)
+
+        Returns:
+            tensor containing the outputs of the attention implementation;
+                shape (batch_size, target_seq_length, hidden_dim)
+        """

--- a/src/continuiti/networks/multi_head_attention.py
+++ b/src/continuiti/networks/multi_head_attention.py
@@ -14,9 +14,11 @@ from .scaled_dot_product_attention import ScaledDotProductAttention
 class MultiHeadAttention(Attention):
     r"""Multi-Head Attention module.
 
-    Module as described in the paper [Attention is All you Need](https://proceedings.neurips.cc/paper_files/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)
-    with optional bias for the projections. This implementation allows to use attention implementations other than the
-    standard scaled dot product attention implemented by the MultiheadAttention PyTorch module.
+    Module as described in the paper [Attention is All you
+    Need](https://proceedings.neurips.cc/paper_files/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)
+    with optional bias for the projections. This implementation allows to use
+    attention implementations other than the standard scaled dot product
+    attention implemented by the MultiheadAttention PyTorch module.
 
     $$MultiHead(Q,K,V)=Concat(head_1,\dots,head_n)W^O + b^O$$
 
@@ -67,7 +69,7 @@ class MultiHeadAttention(Attention):
         self,
         query: torch.Tensor,
         key: torch.Tensor,
-        value: torch,
+        value: torch.Tensor,
         attn_mask: torch.Tensor = None,
     ) -> torch.Tensor:
         r"""Compute the attention scores.

--- a/src/continuiti/networks/multi_head_attention.py
+++ b/src/continuiti/networks/multi_head_attention.py
@@ -1,0 +1,136 @@
+"""
+`continuiti.networks.multi_head_attention`
+
+Multi-Head-Attention in continuiti.
+"""
+
+import torch
+import torch.nn as nn
+
+from .attention import Attention
+from .scaled_dot_product_attention import ScaledDotProductAttention
+
+
+class MultiHeadAttention(Attention):
+    r"""Multi-Head Attention module.
+
+    Module as described in the paper [Attention is All you Need](https://proceedings.neurips.cc/paper_files/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)
+    with optional bias for the projections. This implementation allows to use attention implementations other than the
+    standard scaled dot product attention implemented by the MultiheadAttention PyTorch module.
+
+    $$MultiHead(Q,K,V)=Concat(head_1,\dots,head_n)W^O + b^O$$
+
+    where
+
+    $$head_i=Attention(QW_i^Q+b_i^Q, KW_i^K+b_i^K, VW_i^V+b_i^V).$$
+
+    Args:
+        hidden_dim: dimension of the hidden layers (embedding dimension).
+        n_heads: number of attention heads.
+        attention: implementation of attention (defaults to scaled dot product attention). Needs to have the arguments
+            `query`, `key`, `value`, `attn_mask`, and `dropout_p`.
+        dropout_p: dropout probability.
+        bias: If True, then the projection onto the different heads is performed with bias.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        n_heads: int,
+        attention: Attention = None,
+        dropout_p: float = 0,
+        bias: bool = True,
+    ):
+        super().__init__()
+
+        self.hidden_dim = hidden_dim
+        self.n_heads = n_heads
+        self.dropout_p = dropout_p
+        self.bias = bias
+
+        if attention is None:
+            attention = ScaledDotProductAttention()
+        self.attention = attention
+
+        self.head_dim = hidden_dim // n_heads
+        assert (
+            self.head_dim * n_heads == hidden_dim
+        ), "hidden_dim must be divisible by n_heads"
+
+        # projection networks
+        self.query_project = nn.Linear(hidden_dim, hidden_dim, bias=bias)
+        self.key_project = nn.Linear(hidden_dim, hidden_dim, bias=bias)
+        self.value_project = nn.Linear(hidden_dim, hidden_dim, bias=bias)
+        self.out_project = nn.Linear(hidden_dim, hidden_dim, bias=bias)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch,
+        attn_mask: torch.Tensor = None,
+    ) -> torch.Tensor:
+        r"""Compute the attention scores.
+
+        Args:
+            query: Query tensor of shape (batch_size, target_sequence_length, hidden_dim).
+            key: Key tensor of shape (batch_size, source_sequence_length, hidden_dim).
+            value: Value tensor of shape (batch_size, source_sequence_length, hidden_dim).
+            attn_mask: Attention mask of shape (batch_size, target_sequence_length, source_sequence_length).
+
+        Returns:
+            Attention scores of shape (batch_size, target_sequence_length, hidden_dim).
+        """
+        assert query.ndim == key.ndim == value.ndim == 3, (
+            "Query, key, and value need to have three dimensions (batch_size, ..., hidden_dim). This format ensures that"
+            "the module can correctly apply the multi-head attention mechanism, which includes splitting embeddings "
+            "into multiple heads, applying the internal attention implementation for each head, concatenating and "
+            "projecting results, while ensuring that the attention mask is applied correctly."
+        )
+        assert (
+            query.size(0) == key.size(0) == value.size(0)
+        ), "Batch size does not match for input tensors"
+        assert (
+            query.size(-1) == key.size(-1) == value.size(-1)
+        ), "Embedding/hidden dimension does not match for input tensors"
+
+        batch_size = query.size(0)
+        src_len = key.size(1)
+        tgt_len = query.size(1)
+
+        # project values
+        query = self.query_project(query)
+        key = self.key_project(key)
+        value = self.value_project(value)
+
+        # form individual heads
+        query = query.view(batch_size, -1, self.n_heads, self.head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, self.n_heads, self.head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, self.n_heads, self.head_dim).transpose(1, 2)
+
+        # reshape attention mask to match heads
+        if attn_mask is not None:
+            assert (
+                attn_mask.size(0) == batch_size
+            ), "Attention mask batch size does not match input tensors."
+            assert (
+                attn_mask.size(1) == tgt_len
+            ), "First dimension of the attention mask needs to match target length."
+            assert (
+                attn_mask.size(2) == src_len
+            ), "Second dimension of the attention mask needs to match source length."
+
+            attn_mask = attn_mask.unsqueeze(1)  # mask for a single head
+            attn_mask = attn_mask.repeat(1, self.n_heads, 1, 1)  # mask for every head
+
+        # perform attention
+        attn_out = self.attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+        )
+        attn_out = attn_out.transpose(1, 2).reshape(batch_size, -1, self.hidden_dim)
+
+        # output projection
+        return self.out_project(attn_out)

--- a/src/continuiti/networks/scaled_dot_product_attention.py
+++ b/src/continuiti/networks/scaled_dot_product_attention.py
@@ -1,0 +1,42 @@
+"""
+`continuiti.networks.scaled_dot_product_attention`
+
+Scaled dot product attention module.
+"""
+import torch
+
+from .attention import Attention
+from torch.nn.functional import scaled_dot_product_attention
+
+
+class ScaledDotProductAttention(Attention):
+    """Scaled dot product attention module.
+
+    This module is a wrapper for the torch implementation of the scaled dot product attention mechanism as described in
+    the paper "Attention Is All You Need" by Vaswani et al. (2017). This attention mechanism computes the attention
+    weights based on the dot product of the query and key matrices, scaled by the square root of the dimension of the
+    key vectors. The weights are then applied to the value vectors to obtain the final output.
+    """
+
+    def __init__(self, dropout_p: float = 0.0):
+        super().__init__()
+        self.dropout_p = dropout_p
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch,
+        attn_mask: torch.Tensor = None,
+    ) -> torch.Tensor:
+        if self.training:
+            dropout_p = self.dropout_p
+        else:
+            dropout_p = 0.0
+        return scaled_dot_product_attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+            dropout_p=dropout_p,
+        )

--- a/src/continuiti/networks/scaled_dot_product_attention.py
+++ b/src/continuiti/networks/scaled_dot_product_attention.py
@@ -12,10 +12,12 @@ from torch.nn.functional import scaled_dot_product_attention
 class ScaledDotProductAttention(Attention):
     """Scaled dot product attention module.
 
-    This module is a wrapper for the torch implementation of the scaled dot product attention mechanism as described in
-    the paper "Attention Is All You Need" by Vaswani et al. (2017). This attention mechanism computes the attention
-    weights based on the dot product of the query and key matrices, scaled by the square root of the dimension of the
-    key vectors. The weights are then applied to the value vectors to obtain the final output.
+    This module is a wrapper for the torch implementation of the scaled dot
+    product attention mechanism as described in the paper "Attention Is All You
+    Need" by Vaswani et al. (2017). This attention mechanism computes the
+    attention weights based on the dot product of the query and key matrices,
+    scaled by the square root of the dimension of the key vectors. The weights
+    are then applied to the value vectors to obtain the final output.
     """
 
     def __init__(self, dropout_p: float = 0.0):
@@ -26,13 +28,10 @@ class ScaledDotProductAttention(Attention):
         self,
         query: torch.Tensor,
         key: torch.Tensor,
-        value: torch,
+        value: torch.Tensor,
         attn_mask: torch.Tensor = None,
     ) -> torch.Tensor:
-        if self.training:
-            dropout_p = self.dropout_p
-        else:
-            dropout_p = 0.0
+        dropout_p = self.dropout_p if self.training else 0.0
         return scaled_dot_product_attention(
             query=query,
             key=key,

--- a/tests/networks/test_multi_head.py
+++ b/tests/networks/test_multi_head.py
@@ -1,0 +1,191 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from continuiti.networks import MultiHeadAttention, ScaledDotProductAttention
+
+
+@pytest.fixture(scope="session")
+def some_multi_head_attn():
+    return MultiHeadAttention(
+        hidden_dim=32,
+        n_heads=4,
+        attention=ScaledDotProductAttention(dropout_p=0.25),
+        bias=True,
+    )
+
+
+@pytest.fixture(scope="class")
+def random_qkv():
+    batch_size = 3
+    target_length = 5
+    source_length = 7
+    embedding_dim = 8
+
+    q = torch.rand(batch_size, target_length, embedding_dim)
+    k = torch.rand(batch_size, source_length, embedding_dim)
+    v = torch.rand(batch_size, source_length, embedding_dim)
+    return q, k, v
+
+
+class TestMultiHeadAttention:
+    def test_can_initialize(self, some_multi_head_attn):
+        assert isinstance(some_multi_head_attn, MultiHeadAttention)
+
+    def test_output_shape(self, some_multi_head_attn):
+        batch_size = 3
+        query_size = 5
+        key_val_size = 7
+
+        query = torch.rand(batch_size, query_size, some_multi_head_attn.hidden_dim)
+        key = torch.rand(batch_size, key_val_size, some_multi_head_attn.hidden_dim)
+        val = torch.rand(batch_size, key_val_size, some_multi_head_attn.hidden_dim)
+
+        out = some_multi_head_attn(query, key, val)
+
+        gt_attn = nn.MultiheadAttention(
+            embed_dim=some_multi_head_attn.hidden_dim,
+            num_heads=some_multi_head_attn.n_heads,
+            batch_first=True,
+            bias=True,
+        )
+        correct_out, _ = gt_attn(query, key, val)
+
+        assert out.shape == correct_out.shape
+
+    def test_zero_value(self, random_qkv):
+        """Edge case testing for correctness."""
+        q, k, v = random_qkv
+        v = torch.zeros(v.shape)
+
+        m_attn = MultiHeadAttention(q.size(-1), 4, bias=False)
+
+        # V = 0 -> attn score == 0
+        out = m_attn(q, k, v)
+        assert torch.allclose(out, torch.zeros(out.shape))
+
+    def test_gradient_flow(self, some_multi_head_attn):
+        hidden_size = 32
+        some_multi_head_attn.eval()  # Turn off dropout or other stochastic processes
+        query = key = value = torch.rand((10, 5, hidden_size), requires_grad=True)
+        output = some_multi_head_attn(
+            value,
+            key,
+            query,
+        )
+        output.sum().backward()
+
+        assert query.grad is not None, "Gradients not flowing to query"
+        assert key.grad is not None, "Gradients not flowing to key"
+        assert value.grad is not None, "Gradients not flowing to value"
+
+    def test_equal_to_torch(self, random_qkv):
+        q, k, v = random_qkv
+        mask = torch.rand(q.size(0), q.size(1), k.size(1)) < 0.2
+
+        heads = 2
+        embedding_dim = q.size(-1)
+
+        gt_attn = nn.MultiheadAttention(q.size(-1), heads, batch_first=True)
+        attn = MultiHeadAttention(
+            hidden_dim=q.size(-1),
+            n_heads=heads,
+            attention=ScaledDotProductAttention(dropout_p=0.0),
+            bias=True,
+        )
+
+        # align in projection
+        attn.key_project.weight = nn.Parameter(
+            gt_attn.in_proj_weight[embedding_dim : 2 * embedding_dim, :]
+        )
+        attn.key_project.bias = nn.Parameter(
+            gt_attn.in_proj_bias[embedding_dim : 2 * embedding_dim]
+        )
+
+        attn.value_project.weight = nn.Parameter(
+            gt_attn.in_proj_weight[2 * embedding_dim :, :]
+        )
+        attn.value_project.bias = nn.Parameter(
+            gt_attn.in_proj_bias[2 * embedding_dim :]
+        )
+
+        attn.query_project.weight = nn.Parameter(
+            gt_attn.in_proj_weight[:embedding_dim, :]
+        )
+        attn.query_project.bias = nn.Parameter(gt_attn.in_proj_bias[:embedding_dim])
+
+        # align out projection
+        attn.out_project.weight = nn.Parameter(gt_attn.out_proj.weight)
+        attn.out_project.bias = nn.Parameter(gt_attn.out_proj.bias)
+
+        # forward pass
+        out = attn(q, k, v, attn_mask=mask)
+
+        # torch applies masks differently to scaled-dot-product and multi-head attention (inversed).
+        gt_mask = torch.repeat_interleave(mask, heads, 0).logical_not()
+        ground_truth, _ = gt_attn(q, k, v, need_weights=False, attn_mask=gt_mask)
+
+        assert torch.allclose(
+            out[~torch.isnan(out)], ground_truth[~torch.isnan(ground_truth)]
+        )
+
+    def test_full_mask_identical_to_none(self, random_qkv):
+        heads = 2
+        q, k, v = random_qkv
+
+        mask = torch.ones(q.size(0), q.size(1), k.size(1))
+
+        attn = MultiHeadAttention(
+            hidden_dim=q.size(-1),
+            n_heads=heads,
+            attention=ScaledDotProductAttention(dropout_p=0.0),
+            bias=True,
+        )
+
+        # forward pass
+        out_masked = attn(q, k, v, attn_mask=mask)
+        out_none = attn(q, k, v)
+
+        assert torch.allclose(out_masked, out_none)
+
+    def test_mask_all_but_one(self, random_qkv):
+        q, k, v = random_qkv
+        q.requires_grad = True
+        k.requires_grad = True
+        v.requires_grad = True
+
+        # Masks out the last kvs
+        mask = torch.ones(q.size(0), q.size(1), k.size(1), dtype=torch.bool)
+        mask[:, :, -1] = 0
+
+        attn = MultiHeadAttention(
+            hidden_dim=q.size(-1),
+            n_heads=2,
+            attention=ScaledDotProductAttention(dropout_p=0.0),
+            bias=True,
+        )
+        out = attn(q, k, v, attn_mask=mask)
+
+        eq = torch.sum(out)
+        eq.backward()
+
+        assert not torch.any(torch.isnan(q.grad))
+        assert not torch.any(
+            torch.isclose(q.grad, torch.zeros(q.shape))
+        )  # all queries have a non-zero gradient
+
+        assert not torch.any(torch.isnan(v.grad))
+        unmasked_rows = v.grad[:, :-1, :]  # gradient on unmasked values is non-zero
+        assert not torch.any(
+            torch.isclose(unmasked_rows, torch.zeros(unmasked_rows.shape))
+        )
+        masked_row = v.grad[:, -1, :]  # gradient on masked value is zero
+        assert torch.allclose(masked_row, torch.zeros(masked_row.shape))
+
+        assert not torch.any(torch.isnan(k.grad))
+        unmasked_rows = k.grad[:, :-1, :]  # gradient on unmasked keys is non-zero
+        assert not torch.any(
+            torch.isclose(unmasked_rows, torch.zeros(unmasked_rows.shape))
+        )
+        masked_row = k.grad[:, -1, :]  # gradient on masked key is zero
+        assert torch.allclose(masked_row, torch.zeros(masked_row.shape))

--- a/tests/networks/test_scaled_dot.py
+++ b/tests/networks/test_scaled_dot.py
@@ -1,0 +1,22 @@
+import torch
+from torch.nn.functional import scaled_dot_product_attention
+
+from continuiti.networks import ScaledDotProductAttention
+
+
+def test_forward_correct():
+    batch_size = 3
+    query_size = 5
+    key_val_size = 7
+    hidden_dim = 11
+
+    query = torch.rand(batch_size, query_size, hidden_dim)
+    key = torch.rand(batch_size, key_val_size, hidden_dim)
+    value = torch.rand(batch_size, key_val_size, hidden_dim)
+
+    attn = ScaledDotProductAttention()
+
+    out = attn(query, key, value)
+    gt_out = scaled_dot_product_attention(query, key, value)
+
+    assert torch.allclose(out, gt_out)


### PR DESCRIPTION
# Feature: Multi-Head Attention

## Description

This PR introduces multi-head attention as described in "Attention is All you Need" paper (https://proceedings.neurips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf) with bias for projection mappings.

This pr introduces a sub-module to Continuity that specifically deals with implementations of common networks and structures used for implementations of operators but not operators themselves (neural networks, attention, ...).

### Which issue does this PR tackle?

  - The torch implementation of multi-head-attention always defaults to scaled-dot-product attention (https://github.com/pytorch/pytorch/blob/main/torch/nn/functional.py).

### How does it solve the problem?

  - Multi-head attention with flexible attention implementation.

### How are the changes tested?

  - Added Unit tests for `MultiHeadAttention`.

## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [x] The PR solves the issue it claims to solve and only this one.
- [x] Changes are tested sufficiently and all tests pass.
- [x] Documentation is complete and well-written.
- [x] Changelog has been updated, if necessary.
