### PR TITLE
Split dependencies only into standard and dev.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,5 +29,5 @@ jobs:
           cache: "pip"
       - name: Install
         run: |
-          pip install ".[docs]"
+          pip install ".[dev]"
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           cache: "pip"
       - name: Install
         run: |
-          pip install ".[testing]"
+          pip install ".[dev]"
       - name: Run pytest
         run: |
           pytest -v
@@ -61,7 +61,7 @@ jobs:
           cache: "pip"
       - name: Install
         run: |
-          pip install ".[testing]"
+          pip install ".[dev]"
       - name: Install missing system dependencies
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -86,7 +86,7 @@ jobs:
           cache: "pip"
       - name: Install
         run: |
-          pip install ".[testing]"
+          pip install ".[dev]"
       - name: Run tests and collect coverage
         run: pytest --cov src
       - name: Upload coverage to Codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,15 @@ bug reports and feature requests.
 
 ## Local development
 
-This project uses [black](https://github.com/psf/black) to format code and
-[pre-commit](https://pre-commit.com/) to invoke it as a git pre-commit hook.
+In order to contribute to the library, you will need to set up your local
+development environment. First, clone the repository:
 
-Run the following to set up the pre-commit git hook to run before pushes:
-
-```bash
-pre-commit install --hook-type pre-push
+```shell
+git clone https://github.com/aai-institute/continuiti.git
+cd continuiti
 ```
 
-## Setting up your environment
+### Setting up your environment
 
 We strongly suggest using some form of virtual environment for working with the
 library, e.g., with venv:
@@ -27,11 +26,27 @@ python3 -m venv ./venv
 source venv/bin/activate
 ```
 
+### Installing in editable mode
+
 A very convenient way of working with your library during development is to
-install it in editable mode into your environment by running
+install it in editable mode into your environment by running:
 
 ```shell
-pip install -e .
+pip install -e .[dev]
+```
+
+The `[dev]` extra installs all dependencies needed for development, including
+testing, documentation and benchmarking.
+
+### Pre-commit hooks
+
+This project uses [black](https://github.com/psf/black) to format code and
+[pre-commit](https://pre-commit.com/) to invoke it as a git pre-commit hook.
+
+Run the following to set up the pre-commit git hook to run before pushes:
+
+```bash
+pre-commit install
 ```
 
 ## Build documentation
@@ -39,12 +54,6 @@ pip install -e .
 API documentation and examples from notebooks are built with
 [mkdocs](https://www.mkdocs.org/).
 Notebooks are an integral part of the documentation as well.
-
-Install the documentation dependencies:
-
-```bash
-pip install -e ".[docs]"
-```
 
 You can use this command to continuously rebuild documentation
 on changes to the `docs` and `src` folder:
@@ -64,10 +73,14 @@ by [CI pipelines](#CI). Before pushing your changes to the remote we recommend
 to execute `pytest` locally in order to detect mistakes early on and to avoid
 failing pipelines.
 
-For testing, install the testing dependencies:
+To run all tests, use:
+```shell
+pytest
+```
 
-```bash
-pip install -e ".[testing]"
+To run specific tests, use:
+```shell
+pytest -k test_pattern
 ```
 
 Slow tests (> 5s) are marked by the `@pytest.mark.slow` decorator.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,13 +1,5 @@
 # Benchmarks
 
-## Prerequisites
-
-The benchmarks require optional dependencies:
-
-```bash
-pip install -e ".[benchmark]"
-```
-
 ## Run
 
 Run the `run_all.py` script to run all benchmarks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,6 @@ dependencies = [
     "flake8",           # code analysis
     "isort",            # import sorting
 
-    # --------- loggers --------- #
-    # wandb
-    # neptune-client
-    # mlflow
-    # comet-ml
-    # tensorboard
-
     # --------- linters --------- #
     "pre-commit",       # hooks for applying linters on commit
     "pudb",             # debugger
@@ -43,25 +36,25 @@ dependencies = [
     "python-dotenv",    # loading env variables from .env file
     "rich",             # beautiful text formatting in terminal
     "sh",               # for running bash commands in some tests
-    # dvc               # data version control
 
     # --------- dependencies --------- #
     "torch>=2.1.0,<3.0.0",
     "matplotlib",
     "pandas",
     "numpy",
+    "scipy",
+    "dvc",
+    "dvc-gdrive",
+    "mlflow",
+    "optuna>=3.5.0,<4.0.0",
 ]
 
 [project.optional-dependencies]
-testing = [
+dev = [
     "setuptools",
     "pytest",
     "pytest-cov",
     "nbmake",
-    "gmsh",
-    "mlflow",
-]
-docs = [
     "markdown-captions",
     "mike",
     "mkdocs==1.5.2",
@@ -78,13 +71,7 @@ docs = [
     "mknotebooks>=0.8.0",
     "neoteroi-mkdocs",
     "pygments",
-]
-benchmark = [
-    "dvc",
-    "dvc-gdrive",
-    "mlflow",
-    "optuna>=3.5.0,<4.0.0",
-    "scipy",
+    "gmsh",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
# Cleanup: Split dependencies only into standard and dev.

## Description

### Which issue does this PR tackle?

  - We split the dependencies into default, [docs], [testing], [benchmark] and that becomes confusing.

### How does it solve the problem?

  - Split only into default (including [benchmark]) and dev (including [docs] and [testing])

### How are the changes tested?

  - As before.
