### PR TITLE
Feature: Reduce non-optional dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ docs_build
 
 # MLFlow
 **/mlruns
+
+# Testing
+*.png

--- a/data/README.md
+++ b/data/README.md
@@ -2,26 +2,30 @@
 
 ## Prerequisites
 
-We use `dvc` to manage the data. You can install the required packages by
-installing the benchmarks requirements.
+We use `dvc` to manage the data. Install the required packages by:
 
 ```
-pip install -e .[benchmarks]
+pip install dvc dvc-gdrive
 ```
 
 ## Downloading the data
 
-The data is stored in a remote storage on GDrive.
-To download the data, you can run:
+The data is stored in a remote storage on GDrive, so you need to authenticate
+with the GDrive.
+
+To download, e.g., the `navierstokes` data, run within the `data` directory:
 
 ```
-cd data
-dvc pull <NAME>
+dvc pull navierstokes
 ```
 
-where `<NAME>` is the name of the data set you want to download,
-e.g., `flame` or `navierstokes`, or empty.
+To download all data sets, run:
 
+```
+dvc pull
+```
+
+Below, you can find a list of available data sets.
 
 ## Data sets
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,38 +23,35 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "black",            # code formatting
-    "flake8",           # code analysis
-    "isort",            # import sorting
-
-    # --------- linters --------- #
-    "pre-commit",       # hooks for applying linters on commit
-    "pudb",             # debugger
-    "pytest",           # tests
-
-    # --------- others --------- #
-    "python-dotenv",    # loading env variables from .env file
-    "rich",             # beautiful text formatting in terminal
-    "sh",               # for running bash commands in some tests
-
-    # --------- dependencies --------- #
-    "torch>=2.1.0,<3.0.0",
-    "matplotlib",
-    "pandas",
+    "setuptools",
     "numpy",
+    "matplotlib",
     "scipy",
-    "dvc",
-    "dvc-gdrive",
+    "pandas",
+    "torch>=2.1.0,<3.0.0",
     "mlflow",
-    "optuna>=3.5.0,<4.0.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "setuptools",
+    # === Optional dependencies for tests ===
+    "optuna>=3.5.0,<4.0.0",
+    "gmsh",
+    "deepxde",
+
+    # === Code quality ===
+    "black",
+    "flake8",
+    "isort",
+    "pre-commit",
+    "pudb",
+
+    # === Testing ===
     "pytest",
     "pytest-cov",
     "nbmake",
+
+    # === Documentation ===
     "markdown-captions",
     "mike",
     "mkdocs==1.5.2",
@@ -71,8 +68,6 @@ dev = [
     "mknotebooks>=0.8.0",
     "neoteroi-mkdocs",
     "pygments",
-    "gmsh",
-    "deepxde",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
# Feature: Reduce non optional dependencies

## Description

### Which issue does this PR tackle?

  - We have too many dependencies, many of them are actually optional or only needed for dev/testing.

### How does it solve the problem?

  - Move several dependencies into dev.

### How are the changes tested?

  - Locally: I am able to run `benchmarks/run_single.py` after `pip install -e .` only.
  - All tests run as before with `pip install -e .[dev]` 
