### PR TITLE
Bugfix: Broken Upstream Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "optuna>=3.5.0,<4.0.0",
     "gmsh",
     "deepxde",
+    "scikit-learn<=1.4.2",
 
     # === Code quality ===
     "black",


### PR DESCRIPTION
# Bugfix: Broken Upstream Dependency

## Description

DeepXDE has scikit-learn as an upstream dependency. scikit-learn changed the file path to a specific method (https://github.com/scikit-learn/scikit-learn/commit/e125e67bce7811eefb6f449918dc6aba596678ee) causing this error. The error has been fixed in DeepXDE (https://github.com/lululxvi/deepxde/pull/1760) but still persists in the current release of DeepXDE. This issue exists for over two weeks now.

Once this issue has been addressed in the upstream package or a new release of DeepXDE is available this dependency can and should be removed again.

### Which issue does this PR tackle?

  - Upstream dependency is broken.

### How does it solve the problem?

  - Limits the version of the broken package.

### How are the changes tested?

  - no new errors are introduced.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [ ] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [ ] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [ ] The PR solves the issue it claims to solve and only this one.
- [ ] Changes are tested sufficiently and all tests pass.
- [ ] Documentation is complete and well-written.
- [ ] Changelog has been updated, if necessary.
