### PR TITLE
DeepONet should support arbitrary trunk/branch networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.0
 
 - Add `Attention` base class, `MultiHeadAttention`, and `ScaledDotProductAttention` classes.
+- Add `branch_network` and `trunk_network` arguments to `DeepONet` to allow for custom network architectures.
 
 ## 0.1.0
 

--- a/tests/operators/test_deeponet.py
+++ b/tests/operators/test_deeponet.py
@@ -61,3 +61,34 @@ def test_deeponet():
     # Check solution
     x, u, y, v = dataset.x, dataset.u, dataset.y, dataset.v
     assert MSELoss()(operator, x, u, y, v) < 1e-2
+
+
+@pytest.mark.slow
+def test_custom_deeponet():
+    # Data set
+    n_sensors = 32
+    dataset = SineBenchmark(n_train=1, n_sensors=n_sensors).train_dataset
+
+    # CNN as branch network
+    basis_functions = 8
+    branch_network = torch.nn.Sequential(
+        torch.nn.Conv1d(1, 16, kernel_size=3, padding=1),
+        torch.nn.ReLU(),
+        torch.nn.Conv1d(16, 1, kernel_size=3, padding=1),
+        torch.nn.Flatten(),
+        torch.nn.Linear(n_sensors, basis_functions),
+    )
+
+    # Operator
+    operator = DeepONet(
+        dataset.shapes,
+        branch_network=branch_network,
+        basis_functions=basis_functions,
+    )
+
+    # Train
+    Trainer(operator).fit(dataset, tol=1e-3)
+
+    # Check solution
+    x, u, y, v = dataset.x, dataset.u, dataset.y, dataset.v
+    assert MSELoss()(operator, x, u, y, v) < 1e-3

--- a/tests/operators/test_deeponet.py
+++ b/tests/operators/test_deeponet.py
@@ -64,7 +64,7 @@ def test_deeponet():
 
 
 @pytest.mark.slow
-def test_custom_deeponet():
+def test_custom_branch_network():
     # Data set
     n_sensors = 32
     dataset = SineBenchmark(n_train=1, n_sensors=n_sensors).train_dataset
@@ -83,6 +83,95 @@ def test_custom_deeponet():
     operator = DeepONet(
         dataset.shapes,
         branch_network=branch_network,
+        basis_functions=basis_functions,
+    )
+
+    # Train
+    Trainer(operator).fit(dataset, tol=1e-3)
+
+    # Check solution
+    x, u, y, v = dataset.x, dataset.u, dataset.y, dataset.v
+    assert MSELoss()(operator, x, u, y, v) < 1e-3
+
+
+@pytest.mark.slow
+def test_custom_trunk_network():
+    # Data set
+    n_sensors = 32
+    dataset = SineBenchmark(n_train=1, n_sensors=n_sensors).train_dataset
+
+    # MLP as trunk network
+    basis_functions = 32
+    trunk_network = torch.nn.Sequential(
+        torch.nn.Linear(1, 32),
+        torch.nn.LayerNorm(32),
+        torch.nn.Sigmoid(),
+        torch.nn.Linear(32, 32),
+        torch.nn.BatchNorm1d(32),
+        torch.nn.GELU(),
+        torch.nn.Linear(32, basis_functions),
+    )
+
+    # Operator
+    operator = DeepONet(
+        dataset.shapes,
+        trunk_network=trunk_network,
+        basis_functions=basis_functions,
+    )
+
+    # Train
+    Trainer(operator).fit(dataset, tol=1e-3)
+
+    # Check solution
+    x, u, y, v = dataset.x, dataset.u, dataset.y, dataset.v
+    assert MSELoss()(operator, x, u, y, v) < 1e-3
+
+
+@pytest.mark.slow
+def test_custom_branch_and_trunk_network():
+    # Data set
+    n_sensors = 32
+    dataset = SineBenchmark(n_train=1, n_sensors=n_sensors).train_dataset
+
+    # CNN as branch network
+    basis_functions = 32
+    branch_network = torch.nn.Sequential(
+        torch.nn.Conv1d(1, 16, kernel_size=3, padding=1),
+        torch.nn.ReLU(),
+        torch.nn.Conv1d(16, 1, kernel_size=3, padding=1),
+        torch.nn.Flatten(),
+        torch.nn.Linear(n_sensors, basis_functions),
+    )
+
+    # Custom MLP as trunk network
+    trunk_network = torch.nn.Sequential(
+        torch.nn.Linear(1, 32),
+        torch.nn.LayerNorm(32),
+        torch.nn.Sigmoid(),
+        torch.nn.Linear(32, 32),
+        torch.nn.BatchNorm1d(32),
+        torch.nn.GELU(),
+        torch.nn.Linear(32, basis_functions),
+    )
+
+    # Operator
+    operator = DeepONet(
+        dataset.shapes,
+        branch_network=branch_network,
+        trunk_network=trunk_network,
+    )
+
+    # Train
+    Trainer(operator).fit(dataset, tol=1e-3)
+
+    # Check solution
+    x, u, y, v = dataset.x, dataset.u, dataset.y, dataset.v
+    assert MSELoss()(operator, x, u, y, v) < 1e-3
+
+    # Operator
+    operator = DeepONet(
+        dataset.shapes,
+        trunk_network=trunk_network,
         basis_functions=basis_functions,
     )
 


### PR DESCRIPTION
# Feature: DeepONet should support arbitrary trunk/branch networks

## Description

### Which issue does this PR tackle?

  - Fixes #71 
 
### How does it solve the problem?

  - Adds possibility to use custom branch and trunk network in DeepONet by introducing `branch_network` and `trunk_network` arguments.

### How are the changes tested?

  - Added `test_custom_deeponet`.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [x] The PR solves the issue it claims to solve and only this one.
- [ ] Changes are tested sufficiently and all tests pass.
- [ ] Documentation is complete and well-written.
- [x] Changelog has been updated, if necessary.
