### PR TITLE
Fix: Apply Uniform Attention Masks Explicitly

### DIFF
--- a/src/continuiti/networks/attention.py
+++ b/src/continuiti/networks/attention.py
@@ -7,15 +7,17 @@ Attention base class in continuiti.
 from abc import abstractmethod
 import torch.nn as nn
 import torch
+from typing import Optional
 
 
-class Attention(nn.Module):
-    """Base class for various attention implementations.
+class UniformMaskAttention(nn.Module):
+    """Base class for various attention implementations with uniform masking.
 
-    Attention assigns different parts of an input varying importance without set
-    kernels. The importance of different components is designated using "soft"
-    weights. These weights are assigned according to specific algorithms (e.g.
+    Attention assigns different parts of an input varying importance without set kernels. The importance of different
+    components is designated using "soft" weights. These weights are assigned according to specific algorithms (e.g.
     scaled-dot-product attention).
+    Uniform masking refers to the characteristic that all queries use the same mask. This restriction allows to remove
+    the query dimension from the mask. All queries have access to the same key/value pairs.
     """
 
     def __init__(self):
@@ -27,18 +29,18 @@ class Attention(nn.Module):
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
-        attn_mask: torch.Tensor = None,
+        attn_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Calculates the attention scores.
 
         Args:
-            query: query tensor; shape (batch_size, target_seq_length, hidden_dim)
-            key: key tensor; shape (batch_size, source_seq_length, hidden_dim)
-            value: value tensor; shape (batch_size, source_seq_length, hidden_dim)
+            query: query tensor; shape (batch_size, target_seq_length, hidden_dim).
+            key: key tensor; shape (batch_size, source_seq_length, hidden_dim).
+            value: value tensor; shape (batch_size, source_seq_length, hidden_dim).
             attn_mask: tensor indicating which values are used to calculate the output;
-                shape (batch_size, target_seq_length, source_seq_length)
+                shape (batch_size, source_seq_length).
 
         Returns:
             tensor containing the outputs of the attention implementation;
-                shape (batch_size, target_seq_length, hidden_dim)
+                shape (batch_size, target_seq_length, hidden_dim).
         """

--- a/src/continuiti/networks/scaled_dot_product_attention.py
+++ b/src/continuiti/networks/scaled_dot_product_attention.py
@@ -4,13 +4,14 @@
 Scaled dot product attention module.
 """
 import torch
+from typing import Optional
 
-from .attention import Attention
+from .attention import UniformMaskAttention
 from torch.nn.functional import scaled_dot_product_attention
 
 
-class ScaledDotProductAttention(Attention):
-    """Scaled dot product attention module.
+class ScaledDotProductAttention(UniformMaskAttention):
+    """Scaled dot product attention module with uniform mask.
 
     This module is a wrapper for the torch implementation of the scaled dot
     product attention mechanism as described in the paper "Attention Is All You
@@ -29,9 +30,26 @@ class ScaledDotProductAttention(Attention):
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
-        attn_mask: torch.Tensor = None,
+        attn_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Calculate attention scores.
+
+        Args:
+            query: query tensor; shape (batch_size, target_seq_length, hidden_dim).
+            key: key tensor; shape (batch_size, source_seq_length, hidden_dim).
+            value: value tensor; shape (batch_size, source_seq_length, hidden_dim).
+            attn_mask: tensor indicating which values are used to calculate the output; shape
+                (batch_size, source_seq_length). Defaults to None.
+
+        Returns:
+            tensor containing the outputs of the attention implementation; shape
+                (batch_size, target_seq_length, hidden_dim).
+        """
         dropout_p = self.dropout_p if self.training else 0.0
+
+        if attn_mask is not None:
+            attn_mask = attn_mask.unsqueeze(1)
+
         return scaled_dot_product_attention(
             query=query,
             key=key,

--- a/tests/networks/test_scaled_dot.py
+++ b/tests/networks/test_scaled_dot.py
@@ -4,19 +4,35 @@ from torch.nn.functional import scaled_dot_product_attention
 from continuiti.networks import ScaledDotProductAttention
 
 
-def test_forward_correct():
+class TestScaledDotProductAttention:
     batch_size = 3
     query_size = 5
     key_val_size = 7
     hidden_dim = 11
 
-    query = torch.rand(batch_size, query_size, hidden_dim)
-    key = torch.rand(batch_size, key_val_size, hidden_dim)
-    value = torch.rand(batch_size, key_val_size, hidden_dim)
+    def test_forward_correct(self):
+        query = torch.rand(self.batch_size, self.query_size, self.hidden_dim)
+        key = torch.rand(self.batch_size, self.key_val_size, self.hidden_dim)
+        value = torch.rand(self.batch_size, self.key_val_size, self.hidden_dim)
 
-    attn = ScaledDotProductAttention()
+        attn = ScaledDotProductAttention()
 
-    out = attn(query, key, value)
-    gt_out = scaled_dot_product_attention(query, key, value)
+        out = attn(query, key, value)
+        gt_out = scaled_dot_product_attention(query, key, value)
 
-    assert torch.allclose(out, gt_out)
+        assert torch.allclose(out, gt_out)
+
+    def test_masked_correct(self):
+        query = torch.rand(self.batch_size, self.query_size, self.hidden_dim)
+        key = torch.rand(self.batch_size, self.key_val_size, self.hidden_dim)
+        value = torch.rand(self.batch_size, self.key_val_size, self.hidden_dim)
+        mask = torch.rand(self.batch_size, self.key_val_size) >= 0.2
+
+        attn = ScaledDotProductAttention()
+
+        out = attn(query, key, value, mask)
+
+        gt_mask = mask.unsqueeze(1).repeat(1, query.size(1), 1)
+        out_gt = scaled_dot_product_attention(query, key, value, gt_mask)
+
+        assert torch.allclose(out, out_gt)


### PR DESCRIPTION
# Fix: Apply Uniform Attention Masks Explicitly

## Description

This PR changes the attention base class implementation to an explicit assumption that the attention mask is applied uniformly accross a single sample. This ensures consistency in which parts of the input are masked out or attended to across all queries. Without this assumption the mask needs to be repeated for every query, leading to big overheads. In its current state all queries should have acess to all key/value pairs. While there is potential impplementations utilizing a more efficient/distributed matching, this approach will be not followed for now.

### Which issue does this PR tackle?

  - Handling of query-specific key/value masks is too restricting for simple attention based neural operator implementations.

### How does it solve the problem?

  - Restricts the attention mask to be uniform across all queries.

### How are the changes tested?

  - Modified unit tests to match the new assumption.
  - All unit-tests run without errors.


## Checklist for Contributors

- [ ] Scope: This PR tackles exactly one problem.
- [ ] Conventions: The branch follows the `feature/title-slug` convention.
- [ ] Conventions: The PR title follows the `Bugfix: Title` convention.
- [ ] Coding style: The code passes all pre-commit hooks.
- [ ] Documentation: All changes are well-documented.
- [ ] Tests: New features are tested and all tests pass successfully.
- [ ] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [ ] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [ ] The PR solves the issue it claims to solve and only this one.
- [ ] Changes are tested sufficiently and all tests pass.
- [ ] Documentation is complete and well-written.
- [ ] Changelog has been updated, if necessary.
