### PR TITLE
Fix: Test failing when using DeepXDE

### DIFF
--- a/tests/pde/deepxde_example.py
+++ b/tests/pde/deepxde_example.py
@@ -1,5 +1,4 @@
 import torch
-import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -11,6 +10,10 @@ def deepxde_example():
     Example from DeepXDE.
     https://deepxde.readthedocs.io/en/latest/demos/operator/poisson.1d.pideeponet.html
     """
+
+    # deepxde sets the device context internally, which can conflict with the testing setup, when dealing with different
+    # devices (i.e. GPU and CPU). To ensure that the correct device is set the dependency is isolated.
+    import deepxde as dde  # noqa
 
     # Poisson equation: -u_xx = f
     def equation(x, y, f):

--- a/tests/pde/test_pideeponet.py
+++ b/tests/pde/test_pideeponet.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
 import continuiti as cti
@@ -14,6 +13,10 @@ def test_pideeponet():
     Example from DeepXDE in *continuiti*.
     https://deepxde.readthedocs.io/en/latest/demos/operator/poisson.1d.pideeponet.html
     """
+
+    # deepxde sets the device context internally, which can conflict with the testing setup, when dealing with different
+    # devices (i.e. GPU and CPU). To ensure that the correct device is set the dependency is isolated.
+    import deepxde as dde  # noqa
 
     # Poisson equation: -v_xx = f
     mse = torch.nn.MSELoss()


### PR DESCRIPTION
# Bugfix: Test failing when using DeepXDE

## Description

As discussed [here](https://github.com/lululxvi/deepxde/issues/1796) does DeepXDE internally set the device context when initializing the pytorch backend (https://deepxde.readthedocs.io/en/latest/user/installation.html#pytorch-backend).
This results in errors when running the tests with more than one device. The device context for iterators and instances such as the torch dataloader conflicts. 

### Which issue does this PR tackle?

  - Not all unit tests running on machines with multiple devices, due to device context initialization of DeepXDE.

### How does it solve the problem?

  - Isolates the deepxde import from the rest of the test-code.

### How are the changes tested?

  - All unit tests run without new errors.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [ ] The PR solves the issue it claims to solve and only this one.
- [ ] Changes are tested sufficiently and all tests pass.
- [ ] Documentation is complete and well-written.
- [ ] Changelog has been updated, if necessary.
