### PR TITLE
Feature: Add package typing marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `MaskedOperator` base class.
 - Add `DeepCatOperator`.
 - Restructure documentation, separating notebooks into tutorials and how-to guides.
+- Add support typing information according to PEP 561.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.0
+
+- Add support typing information according to PEP 561.
+
 ## 0.2.0
 
 - Add `Attention` base class, `MultiHeadAttention`, and `ScaledDotProductAttention` classes.
@@ -7,7 +11,6 @@
 - Add `MaskedOperator` base class.
 - Add `DeepCatOperator`.
 - Restructure documentation, separating notebooks into tutorials and how-to guides.
-- Add support typing information according to PEP 561.
 
 ## 0.1.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ dev = [
 where = ["src"]
 include = ["continuiti*"]
 
+[tool.setuptools.package-data]
+"continuiti" = ["py.typed"]
+
 [project.urls]
 Repository = "https://github.com/aai-institute/continuiti.git"
 Documentation = "https://aai-institute.github.io/continuiti/"


### PR DESCRIPTION
# Feature: Add package typing marker

## Description

This pr introduces support for [PEP 561](https://peps.python.org/pep-0561/) to allow downstream users to leverage type hints in our library. By making this change, we provide the necessary metadata for tools like mypy to recognize and validate type hints.

### Which issue does this PR tackle?

  - Continuiti currently does not provide type information.

### How does it solve the problem?

  - Adds `py.typed` file that signals that Continuiti includes type information.
  - Adds `py.typed` to the package data to ensure it is included in the package distribution.

### How are the changes tested?

  - All tests run without new errors.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [x] The PR solves the issue it claims to solve and only this one.
- [x] Changes are tested sufficiently and all tests pass.
- [x] Documentation is complete and well-written.
- [x] Changelog has been updated, if necessary.
